### PR TITLE
fix reclamm template

### DIFF
--- a/subgraphs/v3-pools/subgraph.sonic.yaml
+++ b/subgraphs/v3-pools/subgraph.sonic.yaml
@@ -186,3 +186,26 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleQuantAMMWeightedPoolCreated
       file: ./src/mappings/quantamm.ts
+  - kind: ethereum
+    name: ReClammPoolV2Factory
+    network: sonic
+    source:
+      abi: BasePoolFactory
+      address: "0x99c13B259138a8ad8badbBfB87A4074591310De0"
+      startBlock: 38897147
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Factory
+        - Pool
+      abis:
+        - name: ReClammPool
+          file: ./abis/ReClammPool.json
+        - name: BasePoolFactory
+          file: ./abis/BasePoolFactory.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleReClammPoolV2Created
+      file: ./src/mappings/reclamm.ts

--- a/subgraphs/v3-pools/template.yaml
+++ b/subgraphs/v3-pools/template.yaml
@@ -277,7 +277,7 @@ dataSources:
           handler: handleReClammPoolV2Created
       file: ./src/mappings/reclamm.ts
   {{/if}}
-{{#if ReClammPoolFactory}}
+{{#if ReClammPoolV2Factory}}
 templates:
   - kind: ethereum/contract
     name: ReClammPool


### PR DESCRIPTION
If a chain only has reclammv2, the templates are missing. changed it to check for v2 as I assume there wont be any chain where we only deploy v1.