### PR TITLE
add fallback to eclpparams method

### DIFF
--- a/subgraphs/v3-pools/src/mappings/gyroE.ts
+++ b/subgraphs/v3-pools/src/mappings/gyroE.ts
@@ -8,8 +8,8 @@ import { scaleDown } from "../helpers/math";
 
 function handleGyroEPoolParams(poolAddress: Address): Bytes {
   let gyroEPool = GyroECLPPool.bind(poolAddress);
-  let gyroEResult = gyroEPool.try_getGyroECLPPoolImmutableData();
   let gyroEParams = new GyroEParams(poolAddress);
+  let gyroEResult = gyroEPool.try_getGyroECLPPoolImmutableData();
   if (!gyroEResult.reverted) {
     // Base params - 18 decimals
     gyroEParams.alpha = scaleDown(gyroEResult.value.paramsAlpha, 18);
@@ -28,6 +28,31 @@ function handleGyroEPoolParams(poolAddress: Address): Bytes {
     gyroEParams.w = scaleDown(gyroEResult.value.w, 38);
     gyroEParams.z = scaleDown(gyroEResult.value.z, 38);
     gyroEParams.dSq = scaleDown(gyroEResult.value.dSq, 38);
+  } else {
+    // Fallback for older pool versions (e.g. V2) that expose getECLPParams instead
+    let eclpResult = gyroEPool.try_getECLPParams();
+    if (!eclpResult.reverted) {
+      let params = eclpResult.value.value0;
+      let d = eclpResult.value.value1;
+
+      // Base params - 18 decimals
+      gyroEParams.alpha = scaleDown(params.alpha, 18);
+      gyroEParams.beta = scaleDown(params.beta, 18);
+      gyroEParams.c = scaleDown(params.c, 18);
+      gyroEParams.s = scaleDown(params.s, 18);
+      gyroEParams.lambda = scaleDown(params.lambda, 18);
+
+      // Derived params - 38 decimals
+      gyroEParams.tauAlphaX = scaleDown(d.tauAlpha.x, 38);
+      gyroEParams.tauAlphaY = scaleDown(d.tauAlpha.y, 38);
+      gyroEParams.tauBetaX = scaleDown(d.tauBeta.x, 38);
+      gyroEParams.tauBetaY = scaleDown(d.tauBeta.y, 38);
+      gyroEParams.u = scaleDown(d.u, 38);
+      gyroEParams.v = scaleDown(d.v, 38);
+      gyroEParams.w = scaleDown(d.w, 38);
+      gyroEParams.z = scaleDown(d.z, 38);
+      gyroEParams.dSq = scaleDown(d.dSq, 38);
+    }
   }
   gyroEParams.save();
   return gyroEParams.id;


### PR DESCRIPTION
The ROY pool reverts for `getGyroECLPPoolImmutableData` at its creation block but works at latest. Adding a fallback, as somehow `getECLPParams` returns correctly at creation block.

https://etherscan.io/tx/0x8885634a73451077d6ec6abacc9966044b5deda45cfce7a4412f89a96e61a3b3